### PR TITLE
Recognize major-only HTTP versions

### DIFF
--- a/http-request-response.sublime-syntax
+++ b/http-request-response.sublime-syntax
@@ -8,8 +8,8 @@ file_extensions:
 variables:
   content_type_sep: (?=;|$)
   multipart_form_data_boundary: (?:^---+.*$)
-  http_version: (?:\bHTTP/\d\.\d\b)
-  end_of_body: '^{{http_version}}\s\d{3}\s\w+'
+  http_version: (?:\bHTTP/\d(?:\.\d)?\b)
+  end_of_body: '^{{http_version}} \d{3}(?: \w+)?'
 contexts:
   prototype:
     - match: '^##'


### PR DESCRIPTION
These occur for example in curl's debug output:

  HTTP/2 200

While at it, tolerate only regular space as token separators in
end_of_body (per the spec).