### PR TITLE
Recognize JSON and XML by media type suffixes

### DIFF
--- a/http-request-response.sublime-syntax
+++ b/http-request-response.sublime-syntax
@@ -20,6 +20,7 @@ variables:
   http_version: (?:\bHTTP/\d(?:\.\d)?\b)
   end_of_body: (?=^{{http_version}}[ ]\d{3})
   end_of_headers: (?:^$\n)
+  media_type_suffix_prefix: (?:[\w.-]+/[\w.-]+)
 contexts:
   prototype:
     - match: '^##'
@@ -113,11 +114,11 @@ contexts:
 
   content-type:
     - meta_content_scope: meta.headers.http-request-response
-    - match: (application/json|text/json|[\w.-]+/[\w.-]+\+json){{content_type_sep}}
+    - match: (application/json|text/json|{{media_type_suffix_prefix}}\+json){{content_type_sep}}
       set: [content-type-json, header-value]
     - match: (application/xhtml\+xml|text/html){{content_type_sep}}
       set: [content-type-html, header-value]
-    - match: (application/xml|text/xml|[\w.-]+/[\w.-]+\+xml){{content_type_sep}}
+    - match: (application/xml|text/xml|{{media_type_suffix_prefix}}\+xml){{content_type_sep}}
       set: [content-type-xml, header-value]
     - match: (application/x-www-form-urlencoded){{content_type_sep}}
       set: [content-type-querystring, header-value]

--- a/http-request-response.sublime-syntax
+++ b/http-request-response.sublime-syntax
@@ -113,12 +113,12 @@ contexts:
 
   content-type:
     - meta_content_scope: meta.headers.http-request-response
-    - match: (application/json|text/json){{content_type_sep}}
+    - match: (application/json|text/json|[\w.-]+/[\w.-]+\+json){{content_type_sep}}
       set: [content-type-json, header-value]
-    - match: (application/xml|text/xml){{content_type_sep}}
-      set: [content-type-xml, header-value]
     - match: (application/xhtml\+xml|text/html){{content_type_sep}}
       set: [content-type-html, header-value]
+    - match: (application/xml|text/xml|[\w.-]+/[\w.-]+\+xml){{content_type_sep}}
+      set: [content-type-xml, header-value]
     - match: (application/x-www-form-urlencoded){{content_type_sep}}
       set: [content-type-querystring, header-value]
     - match: (multipart/form-data){{content_type_sep}}


### PR DESCRIPTION
Moved the XML match to after HTML with the assumption that these are processed in order, so that application/xhtml+xml still gets treated as HTML. It seems to for me in bat, but I haven't researched if that's guaranteed to be the case.

The regexps for suffix matching aren't that strict re the main type and beginning of the subtype, so they could match some invalid types. But I guess this would be ok for practical purposes.